### PR TITLE
changes the widget color of guild_member_addition when the user is younger than 3 days

### DIFF
--- a/src/events/guild_member_addition.rs
+++ b/src/events/guild_member_addition.rs
@@ -1,4 +1,7 @@
 use super::*;
+use chrono::{DateTime, Utc};
+use std::time::SystemTime;
+
 pub async fn guild_member_addition(
     ctx: client::Context,
     guild_id: GuildId,
@@ -12,16 +15,24 @@ pub async fn guild_member_addition(
     config
         .channel_bot_traffic
         .send_embed(&ctx, |e| {
+            let date = new_member.user.created_at();
             e.author(|a| a.name("Member Join").icon_url(new_member.user.face()));
             e.title(new_member.user.name_with_disc_and_id());
             e.description(format!("User {} joined the server", new_member.mention()));
             e.field(
                 "Account Creation Date",
-                util::format_date_detailed(new_member.user.created_at()),
+                util::format_date_detailed(date),
                 false,
             );
             if let Some(join_date) = new_member.joined_at {
                 e.field("Join Date", util::format_date(join_date), false);
+            }
+            if date
+                .signed_duration_since(DateTime::<Utc>::from(SystemTime::now()))
+                .num_days()
+                <= 3
+            {
+                e.color(serenity::utils::Color::from_rgb(253, 242, 0));
             }
         })
         .await?;


### PR DESCRIPTION
This is a pretty useless feature as nobody looks at #user-log anyways, but it looks nicer ¯\_(ツ)_/¯
Example: 
![image](https://user-images.githubusercontent.com/30902201/111740767-38ca3e80-887d-11eb-88ae-d5c11cd6097f.png)

Editors Note: Yes, that's the official OSHA "Warning" color.