### PR TITLE
Make info print out the actual date time of joining and account creation

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -26,10 +26,10 @@ pub async fn info(ctx: &client::Context, msg: &Message, mut args: Args) -> Comma
         e.field("ID/Snowflake", mentioned_user_id.to_string(), false);
         e.field(
             "Account creation date",
-            util::format_date_ago(created_at),
+            util::format_date_detailed(created_at),
             false,
         );
-        e.field("Join Date", util::format_date_ago(join_date), false);
+        e.field("Join Date", util::format_date_detailed(join_date), false);
         if !member.roles.is_empty() {
             e.field(
                 "Roles",


### PR DESCRIPTION
#41 This is what it looks like right now, I thought it was a good idea to just reuse the method

![image](https://user-images.githubusercontent.com/26347830/112706347-e2c05100-8ea3-11eb-8d69-e4460c60ee74.png)
