### PR TITLE
add nix flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .env
+flake.lock
 trup.db-*
 trup.db
 cache

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "Trup rewrite in rust";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system:
+    let pkgs = nixpkgs.legacyPackages.${system}; in
+    {
+      devShell = import ./shell.nix { inherit pkgs; };
+    }
+  );
+}


### PR DESCRIPTION
depends on #25 

nix flakes users can use `nix develop`  instead of `nix-shell`