### PR TITLE
Fix minor fetch message inconsistency.

### DIFF
--- a/src/commands/fetch/fetch.rs
+++ b/src/commands/fetch/fetch.rs
@@ -21,7 +21,7 @@ pub async fn fetch(ctx: &client::Context, msg: &Message, mut args: Args) -> Comm
 
     let all_data = get_fetch_and_profile_data_of(&db, mentioned_user_id)
         .await?
-        .user_error("This user has not set their fetch :/")?;
+        .user_error("This user has not set their fetch")?;
 
     let member = guild.member(&ctx, mentioned_user_id).await?;
     let color = member.colour(&ctx).await;


### PR DESCRIPTION
Removes text emoticon ":/" so it follows the same reply pattern of other fail/success messages.