### PR TITLE
Run DB migrations on bot startup

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -30,4 +30,12 @@ impl Db {
             blocklist_cache: Arc::new(Mutex::new(None)),
         })
     }
+
+    pub async fn run_migrations(&self) -> Result<()> {
+        sqlx::migrate!("./migrations")
+            .run(&self.pool)
+            .await
+            .context("Failed to run database migrations")?;
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,8 @@ async fn main() {
 
     let config = Config::from_environment().expect("Failed to load experiment");
 
-    let db = Db::new().await.unwrap();
+    let db = Db::new().await.expect("Failed to initialize database");
+    db.run_migrations().await.unwrap();
 
     // we're manually calling the framework, to only run commands if none of our
     // message_create event handler filters say no.


### PR DESCRIPTION
This PR runs the database migrations on bot startup. This should allow us to fully automate deployment via CI!
