### PR TITLE
Fixed format_count

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -70,7 +70,7 @@ pub fn format_date_detailed(date: chrono::DateTime<chrono::Utc>) -> String {
 pub fn format_count(num: i32) -> String {
     let last_digits = num % 100;
 
-    if last_digits >= 11 && last_digits <= 13 {
+    if (11..=13).contains(&last_digits) {
         format!("{}th", num)
     } else {
         match last_digits % 10 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -66,13 +66,19 @@ pub fn format_date_detailed(date: chrono::DateTime<chrono::Utc>) -> String {
     format!("{} ({})", format_date(date), format_date_ago(date))
 }
 
-/// Format a number into the 1st, 2nd, 3rd, 4th,... format
+/// Format a number into an ordinal, like 1st, 2nd, 3rd
 pub fn format_count(num: i32) -> String {
-    match num {
-        1 => "1st".to_string(),
-        2 => "2nd".to_string(),
-        3 => "3rd".to_string(),
-        _ => format!("{}th", num),
+    let last_digits = num % 100;
+
+    if last_digits >= 11 && last_digits <= 13 {
+        format!("{}th", num)
+    } else {
+        match last_digits % 10 {
+            1 => format!("{}st", num),
+            2 => format!("{}nd", num),
+            3 => format!("{}rd", num),
+            _ => format!("{}th", num),
+        }
     }
 }
 


### PR DESCRIPTION
[`format_count`](https://github.com/unixporn/trup-rs/blob/13809f71cf32606812aec38fa75dbe65f8325853/src/util.rs#L70) only worked for single digit numbers.