### PR TITLE
fix typo

### DIFF
--- a/src/commands/ban.rs
+++ b/src/commands/ban.rs
@@ -64,7 +64,7 @@ async fn do_ban(
         let _ = user
             .dm(&ctx, |m| {
                 m.embed(|e| {
-                    e.title(format!("You where banned from {}", guild.name));
+                    e.title(format!("You were banned from {}", guild.name));
                     e.field("Reason", reason, false)
                 })
             })


### PR DESCRIPTION
# Expected behavior

It's spelled correctly.

# Current behavior (on unixporn/trup-rs:master)

It's spelled incorrectly.

# Current behavior (on 6gk/trup-rs:master)

It's spelled correctly